### PR TITLE
Add meta descriptions plugin

### DIFF
--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -39,6 +39,7 @@ markdown_extensions:
 plugins:
   - search
   - kroki
+  - meta-descriptions
 extra_css:
   - css/extra.css
 extra_javascript:


### PR DESCRIPTION
The meta descriptions plugin is used to auto-generate meta descriptions field in the HTML.

https://pypi.org/project/mkdocs-meta-descriptions-plugin/